### PR TITLE
Stricter typing of operators.

### DIFF
--- a/theories/zify.v
+++ b/theories/zify.v
@@ -76,13 +76,13 @@ Instance Op_leq : BinOp leq :=
   { TBOp := Z.leb; TBOpInj := ltac:(move=> *; rewrite nat_lebE /=; lia) }.
 Add BinOp Op_leq.
 
-Instance Op_geq : BinOp geq := { TBOp := Z.geb; TBOpInj := ltac:(simpl; lia) }.
+Instance Op_geq : BinOp (geq: nat -> nat -> bool) := { TBOp := Z.geb; TBOpInj := ltac:(simpl; lia) }.
 Add BinOp Op_geq.
 
-Instance Op_ltn : BinOp ltn := { TBOp := Z.ltb; TBOpInj := ltac:(simpl; lia) }.
+Instance Op_ltn : BinOp (ltn: nat -> nat -> bool) := { TBOp := Z.ltb; TBOpInj := ltac:(simpl; lia) }.
 Add BinOp Op_ltn.
 
-Instance Op_gtn : BinOp gtn := { TBOp := Z.gtb; TBOpInj := ltac:(simpl; lia) }.
+Instance Op_gtn : BinOp (gtn : nat -> nat -> bool) := { TBOp := Z.gtb; TBOpInj := ltac:(simpl; lia) }.
 Add BinOp Op_gtn.
 
 Lemma Op_minn_subproof n m :
@@ -168,10 +168,8 @@ Lemma Op_eq_op_int_subproof (n m : int) :
   (n == m) = Z.eqb (Z_of_int n) (Z_of_int m).
 Proof. case: n m => ? [] ? //; rewrite /eq_op [LHS]/= /eq_op [LHS]/=; lia. Qed.
 
-Instance Op_eq_op_int : BinOp (@eq_op int_eqType) :=
-  (* {| TBOp := Z.eqb; TBOpInj := Op_eq_op_int_subproof |}. *)
-  mkbop int int bool Z Z bool (@eq_op _) Inj_int_Z Inj_int_Z Inj_bool_bool
-        Z.eqb Op_eq_op_int_subproof.
+Instance Op_eq_op_int : BinOp (@eq_op int_eqType : int -> int -> bool) :=
+ { TBOp := Z.eqb; TBOpInj := Op_eq_op_int_subproof }.
 Add BinOp Op_eq_op_int.
 
 Instance Op_0_int : CstOp 0%R :=
@@ -218,20 +216,16 @@ Lemma Op_int_intmul_subproof n m :
   Z_of_int (n *~ m) = (Z_of_int n * Z_of_int m)%Z.
 Proof. rewrite mulrzz; lia. Qed.
 
-Instance Op_int_intmul : BinOp *~%R%R :=
-  (* {| TBOp := Z.mul; TBOpInj := Op_int_intmul_subproof |}. *)
-  mkbop int int int Z Z Z (@intmul _) Inj_int_Z Inj_int_Z
-        Inj_int_Z Z.mul Op_int_intmul_subproof.
+Instance Op_int_intmul : BinOp ( *~%R%R : int -> int -> int) :=
+ { TBOp := Z.mul; TBOpInj := Op_int_intmul_subproof }.
 Add BinOp Op_int_intmul.
 
 Lemma Op_int_natmul_subproof n m :
   Z_of_int (n *+ m) = (Z_of_int n * Z_of_nat m)%Z.
 Proof. rewrite pmulrn mulrzz; lia. Qed.
 
-Instance Op_int_natmul : BinOp (@GRing.natmul _) :=
-  (* {| TBOp := Z.mul; TBOpInj := Op_int_natmul_subproof |}. *)
-  mkbop int nat int Z Z Z (@GRing.natmul _) Inj_int_Z Inj_nat_Z
-        Inj_int_Z Z.mul Op_int_natmul_subproof.
+Instance Op_int_natmul : BinOp (@GRing.natmul _ : int -> nat -> int) :=
+   { TBOp := Z.mul; TBOpInj := Op_int_natmul_subproof }.
 Add BinOp Op_int_natmul.
 
 Lemma Op_int_scale_subproof (n : int) (m : int^o) :
@@ -246,8 +240,8 @@ Lemma Op_int_exp_subproof n m :
   Z_of_int (n ^+ m) = (Z_of_int n ^ Z.of_nat m)%Z.
 Proof. rewrite -Zpower_nat_Z; elim: m => //= m <-; rewrite exprS; lia. Qed.
 
-Instance Op_int_exp : BinOp (@GRing.exp _) :=
-  {| TBOp := Z.pow; TBOpInj := Op_int_exp_subproof |}.
+Instance Op_int_exp : BinOp (@GRing.exp _ : int -> nat -> int) :=
+  { TBOp := Z.pow; TBOpInj := Op_int_exp_subproof }.
 Add BinOp Op_int_exp.
 
 Instance Op_invz : UnOp intUnitRing.invz :=
@@ -261,7 +255,7 @@ Instance Op_absz : UnOp absz :=
   { TUOp := Z.abs; TUOpInj := ltac:(case=> ? /=; lia) }.
 Add UnOp Op_absz.
 
-Instance Op_int_normr : UnOp Num.norm :=
+Instance Op_int_normr : UnOp (Num.norm: int -> int) :=
   { TUOp := Z.abs; TUOpInj := ltac:(rewrite /Num.norm /=; lia) }.
 Add UnOp Op_int_normr.
 
@@ -285,8 +279,8 @@ Add BinOp Op_int_ltr.
 Lemma Op_int_sgr_subproof n : Z_of_int (Num.sg n) = Z.sgn (Z_of_int n).
 Proof. by case: n => [[]|n] //=; rewrite addn1. Qed.
 
-Instance Op_int_sgr : UnOp Num.sg :=
-  {| TUOp := Z.sgn; TUOpInj := Op_int_sgr_subproof |}.
+Instance Op_int_sgr : UnOp (Num.sg: int -> int) :=
+  { TUOp := Z.sgn; TUOpInj := Op_int_sgr_subproof }.
 Add UnOp Op_int_sgr.
 
 Instance Op_int_sgz : UnOp (@sgz _) := Op_int_sgr.
@@ -296,16 +290,16 @@ Lemma Op_int_min_subproof n m :
   Z_of_int (Num.min n m) = Z.min (Z_of_int n) (Z_of_int m).
 Proof. case: leP; lia. Qed.
 
-Instance Op_int_min : BinOp Num.min :=
-  {| TBOp := Z.min; TBOpInj := Op_int_min_subproof |}.
+Instance Op_int_min : BinOp (Num.min : int -> int -> int) :=
+  { TBOp := Z.min; TBOpInj := Op_int_min_subproof }.
 Add BinOp Op_int_min.
 
 Lemma Op_int_max_subproof n m :
   Z_of_int (Num.max n m) = Z.max (Z_of_int n) (Z_of_int m).
 Proof. case: leP; lia. Qed.
 
-Instance Op_int_max : BinOp Num.max :=
-  {| TBOp := Z.max; TBOpInj := Op_int_max_subproof |}.
+Instance Op_int_max : BinOp (Num.max: int -> int -> int) :=
+  { TBOp := Z.max; TBOpInj := Op_int_max_subproof }.
 Add BinOp Op_int_max.
 
 (******************************************************************************)
@@ -344,8 +338,8 @@ Lemma Op_divz_subproof n m :
   Z_of_int (divz n m) = divZ (Z_of_int n) (Z_of_int m).
 Proof. by rewrite /divZ !Z_of_intK. Qed.
 
-Instance Op_divz : BinOp divz :=
-  {| TBOp := divZ; TBOpInj := Op_divz_subproof |}.
+Instance Op_divz : BinOp (divz: int -> int -> int) :=
+  { TBOp := divZ; TBOpInj := Op_divz_subproof }.
 Add BinOp Op_divz.
 
 Lemma Op_modz_subproof n m :


### PR DESCRIPTION
This is an attempt at making sure that `zify` declared operators have the expected type.
commit https://github.com/coq/coq/pull/11906/commits/85f87a3d0e0528fe36707b43d893631aef9b1b52 enforces that the type of an operator is syntactically the type expected by the injection.

More test are needed to make sure that the added casts do not break `zify`.

PS: Several mathcomp types look weird to me.
For instance, `leq : nat -> nat -> bool` but `geq: simpl_rel nat`;  `divz: int -> int -> int_Ring`  etc.

