### PR TITLE
Adjust two proofs to mathcomp 1.11 (should also work with 1.10)

### DIFF
--- a/theories/zify.v
+++ b/theories/zify.v
@@ -324,9 +324,7 @@ Add UnOp Op_int_sgr.
 
 Lemma Op_int_min_subproof n m :
   Z_of_int (Num.min n m) = Z.min (Z_of_int n) (Z_of_int m).
-Proof.
-  unfold Num.min; destruct (n < m)%R eqn:HD; lia.
-Qed.
+Proof. rewrite /Num.min; case: ifP; lia. Qed.
 
 Instance Op_int_min : BinOp Num.min :=
   {| TBOp := Z.min; TBOpInj := Op_int_min_subproof |}.

--- a/theories/zify.v
+++ b/theories/zify.v
@@ -332,9 +332,7 @@ Add BinOp Op_int_min.
 
 Lemma Op_int_max_subproof n m :
   Z_of_int (Num.max n m) = Z.max (Z_of_int n) (Z_of_int m).
-Proof.
-  unfold Num.max; destruct (n < m)%R eqn:HD; lia.
-Qed.
+Proof. rewrite /Num.max; case: ifP; lia. Qed.
 
 Instance Op_int_max : BinOp Num.max :=
   {| TBOp := Z.max; TBOpInj := Op_int_max_subproof |}.

--- a/theories/zify.v
+++ b/theories/zify.v
@@ -324,7 +324,9 @@ Add UnOp Op_int_sgr.
 
 Lemma Op_int_min_subproof n m :
   Z_of_int (Num.min n m) = Z.min (Z_of_int n) (Z_of_int m).
-Proof. case: minrP; lia. Qed.
+Proof.
+  unfold Num.min; destruct (n < m)%R eqn:HD; lia.
+Qed.
 
 Instance Op_int_min : BinOp Num.min :=
   {| TBOp := Z.min; TBOpInj := Op_int_min_subproof |}.
@@ -332,7 +334,9 @@ Add BinOp Op_int_min.
 
 Lemma Op_int_max_subproof n m :
   Z_of_int (Num.max n m) = Z.max (Z_of_int n) (Z_of_int m).
-Proof. case: maxrP; lia. Qed.
+Proof.
+  unfold Num.max; destruct (n < m)%R eqn:HD; lia.
+Qed.
 
 Instance Op_int_max : BinOp Num.max :=
   {| TBOp := Z.max; TBOpInj := Op_int_max_subproof |}.


### PR DESCRIPTION
Fixes #9

I didn't find an equivalent of minrP and maxrP in matchcomp 1.11, so the proof is more elementary. I think it should work for both, mathcomp 1.10 and 1.11.